### PR TITLE
Change TTL indexes to packet.added key

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
   "dependencies": {
     "aedes-cached-persistence": "^8.1.0",
     "escape-string-regexp": "^4.0.0",
+    "fastparallel": "^2.3.0",
     "mongodb": "^3.6.0",
     "native-url": "^0.3.1",
     "pump": "^3.0.0",

--- a/persistence.js
+++ b/persistence.js
@@ -104,15 +104,15 @@ MongoPersistence.prototype._setup = function () {
         }
 
         if (that._opts.ttl.packets.will >= 0) {
-          will.createIndex({ added: 1 }, { expireAfterSeconds: that._opts.ttl.packets.will, name: 'ttl' })
+          will.createIndex({ 'packet.added': 1 }, { expireAfterSeconds: that._opts.ttl.packets.will, name: 'ttl' })
         }
 
         if (that._opts.ttl.packets.outgoing >= 0) {
-          outgoing.createIndex({ added: 1 }, { expireAfterSeconds: that._opts.ttl.packets.outgoing, name: 'ttl' })
+          outgoing.createIndex({ 'packet.added': 1 }, { expireAfterSeconds: that._opts.ttl.packets.outgoing, name: 'ttl' })
         }
 
         if (that._opts.ttl.packets.incoming >= 0) {
-          incoming.createIndex({ added: 1 }, { expireAfterSeconds: that._opts.ttl.packets.incoming, name: 'ttl' })
+          incoming.createIndex({ 'packet.added': 1 }, { expireAfterSeconds: that._opts.ttl.packets.incoming, name: 'ttl' })
         }
       }
 

--- a/test.js
+++ b/test.js
@@ -382,25 +382,27 @@ function runTest (client, db) {
         instance.on('ready', function () {
           t.pass('instance ready')
 
-          db.collection('retained').indexInformation({ full: true }, function (err, indexes) {
-            t.notOk(err, 'no error')
-            t.deepEqual({ added: 1 }, indexes[1].key, 'must return the index key')
-
-            db.collection('incoming').indexInformation({ full: true }, function (err, indexes) {
+          setImmediate(function () {
+            db.collection('retained').indexInformation({ full: true }, function (err, indexes) {
               t.notOk(err, 'no error')
-              t.deepEqual({ 'packet.added': 1 }, indexes[1].key, 'must return the index key')
+              t.deepEqual({ added: 1 }, indexes[1].key, 'must return the index key')
 
-              db.collection('outgoing').indexInformation({ full: true }, function (err, indexes) {
+              db.collection('incoming').indexInformation({ full: true }, function (err, indexes) {
                 t.notOk(err, 'no error')
                 t.deepEqual({ 'packet.added': 1 }, indexes[1].key, 'must return the index key')
 
-                db.collection('will').indexInformation({ full: true }, function (err, indexes) {
+                db.collection('outgoing').indexInformation({ full: true }, function (err, indexes) {
                   t.notOk(err, 'no error')
                   t.deepEqual({ 'packet.added': 1 }, indexes[1].key, 'must return the index key')
 
-                  instance.destroy(function () {
-                    t.pass('Instance dies')
-                    emitter.close(t.end.bind(t))
+                  db.collection('will').indexInformation({ full: true }, function (err, indexes) {
+                    t.notOk(err, 'no error')
+                    t.deepEqual({ 'packet.added': 1 }, indexes[1].key, 'must return the index key')
+
+                    instance.destroy(function () {
+                      t.pass('Instance dies')
+                      emitter.close(t.end.bind(t))
+                    })
                   })
                 })
               })

--- a/test.js
+++ b/test.js
@@ -386,9 +386,14 @@ function runTest (client, db) {
             t.notOk(err, 'no error')
             t.deepEqual({ added: 1 }, indexes[1].key, 'must return the index key')
 
-            instance.destroy(function () {
-              t.pass('Instance dies')
-              emitter.close(t.end.bind(t))
+            db.collection('outgoing').indexInformation({ full: true }, function (err, indexes) {
+              t.notOk(err, 'no error')
+              t.deepEqual({ 'packet.added': 1 }, indexes[1].key, 'must return the index key')
+
+              instance.destroy(function () {
+                t.pass('Instance dies')
+                emitter.close(t.end.bind(t))
+              })
             })
           })
         })

--- a/test.js
+++ b/test.js
@@ -382,27 +382,25 @@ function runTest (client, db) {
         instance.on('ready', function () {
           t.pass('instance ready')
 
-          setImmediate(function () {
-            db.collection('retained').indexInformation({ full: true }, function (err, indexes) {
-              t.notOk(err, 'no error')
-              t.deepEqual({ added: 1 }, indexes[1].key, 'must return the index key')
+          db.collection('retained').indexInformation({ full: true }, function (err, indexes) {
+            t.notOk(err, 'no error')
+            t.deepEqual({ added: 1 }, indexes[1].key, 'must return the index key')
 
-              db.collection('incoming').indexInformation({ full: true }, function (err, indexes) {
+            db.collection('incoming').indexInformation({ full: true }, function (err, indexes) {
+              t.notOk(err, 'no error')
+              t.deepEqual({ 'packet.added': 1 }, indexes[1].key, 'must return the index key')
+
+              db.collection('outgoing').indexInformation({ full: true }, function (err, indexes) {
                 t.notOk(err, 'no error')
                 t.deepEqual({ 'packet.added': 1 }, indexes[1].key, 'must return the index key')
 
-                db.collection('outgoing').indexInformation({ full: true }, function (err, indexes) {
+                db.collection('will').indexInformation({ full: true }, function (err, indexes) {
                   t.notOk(err, 'no error')
                   t.deepEqual({ 'packet.added': 1 }, indexes[1].key, 'must return the index key')
 
-                  db.collection('will').indexInformation({ full: true }, function (err, indexes) {
-                    t.notOk(err, 'no error')
-                    t.deepEqual({ 'packet.added': 1 }, indexes[1].key, 'must return the index key')
-
-                    instance.destroy(function () {
-                      t.pass('Instance dies')
-                      emitter.close(t.end.bind(t))
-                    })
+                  instance.destroy(function () {
+                    t.pass('Instance dies')
+                    emitter.close(t.end.bind(t))
                   })
                 })
               })


### PR DESCRIPTION
- Change index key from `packet` to `packet.added` on the `will`, `outgoing`, and `incoming` collections.

Fixes https://github.com/moscajs/aedes-persistence-mongodb/issues/50