### PR TITLE
Fix error emit on the correct object.

### DIFF
--- a/persistence.js
+++ b/persistence.js
@@ -65,7 +65,7 @@ MongoPersistence.prototype._setup = function () {
 
   this._connect(function (err, client) {
     if (err) {
-      this.emit('error', err)
+      that.emit('error', err)
       return
     }
 


### PR DESCRIPTION
**Describe the bug**
When MongoDB authentication fails the error is not emitted, but instead the application crashed with `TypeError: Cannot read property 'emit' of undefined`. The reason for this is the invalid object on which emit is invoked and the fix is very quick:

Lines 66-70
```  
 this._connect(function (err, client) {
   if (err) {
      this.emit('error', err)
      return
   }
```

should be

Lines 66-70
```  
 this._connect(function (err, client) {
   if (err) {
      that.emit('error', err)
      return
   }
```
Note "**that**" reference to the outer scope instead of referring to the function scope "**this**".