### PR TITLE
feat: add support for passing `mongoOptions` to mongoDB driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,17 +30,25 @@ It accepts a connections string `url` or you can pass your existing `db` object.
 ### Options
 
 - `url`: The MongoDB connection url
+- `mongoOptions`: Extra options to pass to MongoDB driver (see [node-mongodb-native](http://mongodb.github.io/node-mongodb-native/3.6/api/MongoClient.html))
 - `ttl`: Used to set a ttl (time to live) to documents stored in collections
   - `packets`: Could be an integer value that specify the ttl in seconds of all packets collections or an Object that specifies for each collection its ttl in seconds. Packets collections are: `incoming`, `outgoing`, `retained`, `will`.
   - `susbscriptions`: Set a ttl (in seconds)
 - `db`: Existing MongoDB instance (if no `url` option is specified)
-- `dropExistingIndexes`: Flag used to drop any exsisting index previously created on collections (except default index `_id`)
+- `dropExistingIndexes`: Flag used to drop any existing index previously created on collections (except default index `_id`)
 
 ### Examples
 
 ```js
 aedesPersistenceMongoDB({
   url: 'mongodb://127.0.0.1/aedes-test', // Optional when you pass db object
+  // Optional mongo options
+  mongoOptions: { 
+    auth: {
+      user: 'username',
+      password: 'password'
+    }
+  },
   // Optional ttl settings
   ttl: {
       packets: 300, // Number of seconds

--- a/persistence.js
+++ b/persistence.js
@@ -53,7 +53,13 @@ MongoPersistence.prototype._connect = function (cb) {
 
   const conn = this._opts.url || 'mongodb://127.0.0.1/aedes'
 
-  mongodb.MongoClient.connect(conn, { useNewUrlParser: true, useUnifiedTopology: true }, cb)
+  const options = { useNewUrlParser: true, useUnifiedTopology: true }
+
+  if (this._opts.mongoOptions) {
+    Object.assign(options, this._opts.mongoOptions)
+  }
+
+  mongodb.MongoClient.connect(conn, options, cb)
 }
 
 MongoPersistence.prototype._setup = function () {

--- a/test.js
+++ b/test.js
@@ -665,4 +665,25 @@ function runTest (client, db) {
       })
     })
   })
+
+  var dboptsWithUrlMongoOptions = {
+    url: mongourl,
+    mongoOptions: {
+      appname: 'TEST'
+    }
+  }
+
+  test('should pass mongoOptions to mongodb driver', function (t) {
+    var instance = persistence(dboptsWithUrlMongoOptions)
+    instance._connect(function (err, client) {
+      t.error(err)
+      for (var opt in dboptsWithUrlMongoOptions.mongoOptions) {
+        t.equal(dboptsWithUrlMongoOptions.mongoOptions[opt], client.s.options[opt], 'must pass options to mongodb')
+      }
+      client.close(function () {
+        t.pass('Client closed')
+        t.end()
+      })
+    })
+  })
 }


### PR DESCRIPTION
In some cases it is necessary to pass options to the MongoDB connect method. This can already be achieved using the `db` parameter instead of supplying `url`. But because it is such a small change to allow this to be supplied along the url parameter I think it should be supported.