### PR TITLE
feat: alternative behavior of subscription ttl #78

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ It accepts a connections string `url` or you can pass your existing `db` object.
 - `dropExistingIndexes`: Flag used to drop any existing index previously created on collections (except default index `_id`)
 - `ttlAfterDisconnected`: Flag used to enable alternative behavior of the subscription ttl, the subscription will expire based on time since client last disconnected from the broker instead of time since the subscription was created.
 
+> When changing ttl durations or switching on/off **ttlAfterDisconnected** on an existing database, **dropExistingIndexes** needs to be set to true for ttl indexes to be updated.
+
 ### Examples
 
 ```js

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ It accepts a connections string `url` or you can pass your existing `db` object.
   - `susbscriptions`: Set a ttl (in seconds)
 - `db`: Existing MongoDB instance (if no `url` option is specified)
 - `dropExistingIndexes`: Flag used to drop any existing index previously created on collections (except default index `_id`)
+- `ttlAfterDisconnected`: Flag used to enable alternative behavior of the subscription ttl, the subscription will expire based on time since client last disconnected from the broker instead of time since the subscription was created.
 
 ### Examples
 


### PR DESCRIPTION
As discussed in #78 this adds a another way of dealing with TTL for subscriptions.

* Adds a new option called `ttlAfterDisconnected` that enables the new functionality.
* The `added` field is left unchanged and the ttl index is instead created for a new field called `disconnected`.
* The disconnected field is automatically set to current date when a client disconnects and cleared in case client reconnects before it expires.
* To avoid stale subscriptions remaining after a previous broker shutdown, the disconnected field is automatically set for all subscriptions on startup (if not already set).
* Added a simple test for subscription ttl index.

Worth noting is that if changing to the new functionality on an existing setup `dropExistingIndexes` needs to be enabled or the index will not update correctly, not sure if this should be made clearer in the documentation.