### PR TITLE
chore: update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,16 +56,16 @@
   "devDependencies": {
     "@fastify/pre-commit": "^2.2.0",
     "c8": "^10.1.3",
-    "eslint": "^9.26.0",
+    "eslint": "^9.30.1",
     "license-checker": "^25.0.1",
     "mqemitter-mongodb": "^9.0.1",
-    "neostandard": "^0.12.1",
+    "neostandard": "^0.12.2",
     "release-it": "^19.0.3"
   },
   "dependencies": {
-    "aedes-persistence": "^10.2.0",
+    "aedes-persistence": "^10.2.2",
     "escape-string-regexp": "^4.0.0",
-    "mongodb": "6.16",
+    "mongodb": "6.17",
     "qlobber": "^8.0.1"
   }
 }


### PR DESCRIPTION
This PR updates:
-  aedes-persistence ^10.2.0  →  ^10.2.2
-  eslint       ^9.26.0  →  ^9.30.1
-  mongodb         6.16  →     6.17
-  neostandard  ^0.12.1  →  ^0.12.2