### PR TITLE
Fix url parse for node 20+ compatibility

### DIFF
--- a/asyncPersistence.js
+++ b/asyncPersistence.js
@@ -125,7 +125,15 @@ class AsyncMongoPersistence {
 
       const mongoDBclient = new MongoClient(conn, options)
       this.#mongoDBclient = mongoDBclient
-      const urlParsed = URL.parse(this.#opts.url)
+
+      let urlParsed;
+      try {
+        urlParsed = new URL(this.#opts.url);
+      } catch {
+        const { parse } = await import('node:url');
+        urlParsed = parse(this.#opts.url);
+      }
+
       // skip the first / of the pathname if it exists
       const pathname = urlParsed.pathname ? urlParsed.pathname.substring(1) : undefined
       const databaseName = this.#opts.database || pathname


### PR DESCRIPTION
Url.parse() results in "does not exist" error on NodeJS 20+ I believe.

This is a small fix to support bot methods.