### PR TITLE
fix: add unique index on retained.topic to prevent COLLSCAN stalls

### DIFF
--- a/asyncPersistence.js
+++ b/asyncPersistence.js
@@ -165,6 +165,9 @@ class AsyncMongoPersistence {
       if (typeof idx.expireAfterSeconds === 'number') {
         indexOpts.expireAfterSeconds = idx.expireAfterSeconds
       }
+      if (idx.unique) {
+        indexOpts.unique = true
+      }
       await this.#cl[idx.collection].createIndex(idx.key, indexOpts)
     }
 
@@ -188,6 +191,19 @@ class AsyncMongoPersistence {
         collection: 'incoming',
         key: { clientId: 1, 'packet.messageId': 1 },
         name: 'query_clientId_messageId'
+      },
+      {
+        // storeRetained / createRetainedStreamCombi key off `topic`. Without
+        // this index every operation falls back to COLLSCAN; under load
+        // storeRetained's ordered bulkWrite serializes the whole publish
+        // pipeline behind it, stalling broker.publish callbacks by tens of
+        // seconds on deployments with more than a few thousand retained
+        // topics (observed: ~60s uniform lag with 15k retained + 200 msg/s).
+        // Unique matches the {topic}-filtered upsert semantics.
+        collection: 'retained',
+        key: { topic: 1 },
+        name: 'query_topic',
+        unique: true
       }
     ]
 


### PR DESCRIPTION
## Summary
- Adds a `unique` index on `retained.topic`, matching the `{topic}`-filtered upsert semantics in `storeRetained`.
- Extends the index factory to honor the `unique` flag (previously only `expireAfterSeconds` was forwarded).

## Why
Without an index on `retained.topic`, every `storeRetained` upsert and `createRetainedStreamCombi` lookup falls back to a collection scan. Under load, the ordered `bulkWrite` in `storeRetained` serializes the whole publish pipeline behind those scans, stalling `broker.publish` callbacks by tens of seconds on deployments with thousands of retained topics (observed: ~60s uniform lag with 15k retained topics at 200 msg/s).

The unique constraint is safe because all writes go through an upsert filtered by `topic`, so the collection already maintains one document per topic by construction.

## Test plan
- [x] `npm run lint` clean on changed file
- [x] `node --test test/abs.js test/own.js` — all 66 tests pass against MongoDB 8.0.9

## Upgrade note
On existing deployments, MongoDB will refuse to build the unique index if duplicate `topic` values exist in the `retained` collection. In normal operation this should not happen (the upsert filter guarantees uniqueness), but operators may want to audit before upgrading.