### PR TITLE
fix: budget retained regex by compiled source length

### DIFF
--- a/asyncPersistence.js
+++ b/asyncPersistence.js
@@ -14,24 +14,22 @@ const QLOBBER_OPTIONS = {
 }
 
 // Batching limits for retained message pattern queries
-// MongoDB has a BSON document size limit of 16MB, but regex patterns hit
-// practical compilation/execution limits around 32KB. These values are tuned
-// to prevent "regular expression is too large" errors while maintaining good
-// query performance.
 //
-// Why two limits?
-// - MAX_TOTAL_PATTERN_LENGTH: Prevents MongoDB regex size errors (~32KB limit)
-//   Cumulative pattern length is tracked to stay well under MongoDB's practical
-//   regex limit, providing a safety margin for regex escaping and construction.
+// MongoDB refuses to compile a regex whose pattern exceeds 16384 bytes:
+//   "Regular expression is invalid: pattern string is longer than the limit
+//    set by the application" (error 51091)
 //
-// - MAX_PATTERNS_PER_BATCH: Optimizes query performance by reducing network overhead
-//   Larger batches mean fewer MongoDB queries, which typically improves performance
-//   more than smaller batches with simpler regex patterns.
+// - MAX_REGEX_SOURCE_LENGTH: budget for the pattern MongoDB actually compiles,
+//   which is `RegExp.source` — NOT the raw subscription filter. V8 escapes every
+//   `/` as `\/` in `source`, and MQTT filters are slash-delimited, so a deep
+//   topic tree inflates ~10% on top of regEscape's own expansions (`-` becomes
+//   `\x2d`, four bytes for one). Budgeting against raw lengths silently
+//   overshoots the 16384 limit; always measure with {@link sourceLength}.
 //
-// These values balance safety (preventing regex errors) with performance (minimizing
-// the number of database queries needed to process subscription patterns).
+// - MAX_PATTERNS_PER_BATCH: caps `$in` size and regex branch count so a client
+//   subscribing to thousands of filters issues bounded queries.
 const MAX_PATTERNS_PER_BATCH = 200
-const MAX_TOTAL_PATTERN_LENGTH = 15000
+const MAX_REGEX_SOURCE_LENGTH = 15000
 
 class AsyncMongoPersistence {
   // private class members start with #
@@ -302,82 +300,36 @@ class AsyncMongoPersistence {
   }
 
   async * createRetainedStreamCombi (patterns) {
+    // Early return for empty patterns to avoid a filter that would match every
+    // document in the collection
+    if (patterns.length === 0) {
+      return
+    }
+
     const matcher = new Qlobber(QLOBBER_OPTIONS)
 
     for (let i = 0; i < patterns.length; i++) {
       matcher.add(patterns[i], true)
     }
 
-    // Calculate total pattern length
-    const totalLength = patterns.reduce((sum, p) => sum + p.length, 0)
+    const filters = buildRetainedFilters(patterns)
+    // A topic can match several filters; only dedupe when that's possible
+    const seenTopics = filters.length > 1 ? new Set() : null
 
-    // Determine if we need to batch
-    const needsBatching =
-      patterns.length > MAX_PATTERNS_PER_BATCH ||
-      totalLength > MAX_TOTAL_PATTERN_LENGTH
-
-    if (needsBatching) {
-      // Process patterns in batches to avoid creating regex that's too large
-      // Use dynamic batching based on cumulative length
-      const seenTopics = new Set() // Track yielded packets to avoid duplicates
-      const batches = []
-      let currentBatch = []
-      let currentLength = 0
-
-      for (const pattern of patterns) {
-        const patternLength = pattern.length
-
-        // Edge case: if a single pattern exceeds MAX_TOTAL_PATTERN_LENGTH,
-        // it will be placed in its own batch. This is intentional behavior
-        // to ensure the pattern is still processed (MongoDB will handle it
-        // or fail with a clear error). Very long patterns (>32KB after escaping)
-        // may still cause MongoDB "regular expression is too large" errors.
-
-        // Start a new batch if adding this pattern would exceed limits
-        if (currentBatch.length >= MAX_PATTERNS_PER_BATCH ||
-            (currentLength + patternLength > MAX_TOTAL_PATTERN_LENGTH && currentBatch.length > 0)) {
-          batches.push(currentBatch)
-          currentBatch = []
-          currentLength = 0
-        }
-        currentBatch.push(pattern)
-        currentLength += patternLength
-      }
-      // Add the last batch if not empty
-      if (currentBatch.length > 0) {
-        batches.push(currentBatch)
-      }
-
-      for (const batch of batches) {
-        for await (const packet of this.#queryRetainedByPatterns(batch, matcher)) {
-          // Avoid duplicates across batches
-          if (!seenTopics.has(packet.topic)) {
-            seenTopics.add(packet.topic)
-            yield packet
+    for (const filter of filters) {
+      for await (const packet of this.#queryRetained(filter, matcher)) {
+        if (seenTopics) {
+          if (seenTopics.has(packet.topic)) {
+            continue
           }
+          seenTopics.add(packet.topic)
         }
-      }
-    } else {
-      // Original logic for small pattern sets
-      for await (const packet of this.#queryRetainedByPatterns(patterns, matcher)) {
         yield packet
       }
     }
   }
 
-  async * #queryRetainedByPatterns (patterns, matcher) {
-    // Early return for empty patterns to avoid creating an empty regex
-    // that would match all documents in the collection
-    if (patterns.length === 0) {
-      return
-    }
-
-    const regexes = patterns.map(pattern =>
-      regEscape(pattern).replace(/(\/*#|\\\+).*$/, '')
-    )
-
-    const topic = new RegExp(regexes.join('|'))
-    const filter = { topic }
+  async * #queryRetained (filter, matcher) {
     const exclude = { _id: 0 }
 
     for await (const result of this.#cl.retained.find(filter).project(exclude)) {
@@ -593,6 +545,81 @@ class AsyncMongoPersistence {
       yield sub.clientId
     }
   }
+}
+
+// The pattern MongoDB compiles is `RegExp.source`, which escapes characters the
+// raw filter does not (notably `/` as `\/`). Measure what the server receives.
+function sourceLength (pattern) {
+  return new RegExp(pattern).source.length
+}
+
+// Literal prefix a topic must start with to have any chance of matching this
+// filter. `#` also matches the parent level (`a/b` matches `a/b/#`), so trailing
+// slashes are dropped. Returns '' when the filter can match any topic.
+function literalPrefix (filter) {
+  const wildcard = filter.search(/[#+]/)
+  if (wildcard === -1) {
+    return filter
+  }
+  const prefix = filter.slice(0, wildcard)
+  return filter[wildcard] === '#' ? prefix.replace(/\/+$/, '') : prefix
+}
+
+// Anchored branch for one prefix, guaranteed to fit the budget on its own:
+// escaping can quadruple a character (`-` becomes `\x2d`), so an oversized
+// prefix is truncated. The regex only pre-filters — `matcher.match` decides the
+// real matches — so a shorter prefix stays correct, it just yields more
+// candidates to filter out.
+function prefixBranch (prefix) {
+  const maxRaw = Math.floor(MAX_REGEX_SOURCE_LENGTH / 4)
+  return `^${regEscape(prefix.length > maxRaw ? prefix.slice(0, maxRaw) : prefix)}`
+}
+
+// Query filters covering `patterns`, each small enough for MongoDB to compile.
+// Filters without a wildcard go through `$in`, wildcard filters become
+// `^`-anchored prefixes: both keep the `topic` index scan bounded, where an
+// unanchored alternation has to walk the whole index.
+function buildRetainedFilters (patterns) {
+  const exact = []
+  const prefixes = []
+
+  for (const pattern of patterns) {
+    const prefix = literalPrefix(pattern)
+    if (prefix === '') {
+      return [{}] // matches every topic, narrowing it further buys nothing
+    }
+    if (prefix === pattern) {
+      exact.push(pattern)
+    } else {
+      prefixes.push(prefix)
+    }
+  }
+
+  const filters = []
+
+  for (let i = 0; i < exact.length; i += MAX_PATTERNS_PER_BATCH) {
+    filters.push({ topic: { $in: exact.slice(i, i + MAX_PATTERNS_PER_BATCH) } })
+  }
+
+  let branches = []
+  let length = 0
+  for (const prefix of prefixes) {
+    const branch = prefixBranch(prefix)
+    const cost = sourceLength(branch) + 1 // + the `|` that joins it to the batch
+    if (branches.length >= MAX_PATTERNS_PER_BATCH ||
+        (length + cost > MAX_REGEX_SOURCE_LENGTH && branches.length > 0)) {
+      filters.push({ topic: new RegExp(branches.join('|')) })
+      branches = []
+      length = 0
+    }
+    branches.push(branch)
+    length += cost
+  }
+  if (branches.length > 0) {
+    filters.push({ topic: new RegExp(branches.join('|')) })
+  }
+
+  return filters
 }
 
 function decoratePacket (packet, setTTL) {

--- a/test/own.js
+++ b/test/own.js
@@ -690,6 +690,96 @@ async function doTest () {
     await cleanUpPersistence(t, p1)
   })
 
+  test('retained messages batching: slash-heavy patterns stay under the MongoDB regex limit', async (t) => {
+    t.plan(3)
+    await cleanDB()
+    const p1 = await setUpPersistence(t, '1', defaultDBopts)
+
+    // 200 filters of 75 chars with 7 slashes each: MongoDB compiles
+    // `RegExp.source`, where every `/` costs an extra `\`, so joining these into
+    // one alternation overshoots the 16384-byte limit (error 51091) even though
+    // their raw length does not.
+    const topics = []
+    for (let i = 0; i < 200; i++) {
+      const leaf = `leaf${i}`.padEnd(28, 'x')
+      topics.push(`regression/slash/heavy/topic/tree/branch/${leaf}/value`)
+    }
+
+    // Guard the fixture: it is only a regression test while it sits in the
+    // regime that used to break.
+    const rawLength = topics.reduce((sum, topic) => sum + topic.length, 0)
+    const joinedLength = new RegExp(topics.join('|')).source.length
+    t.assert.ok(rawLength <= 15000, `raw length ${rawLength} must stay within the old budget`)
+    t.assert.ok(joinedLength > 16384, `joined source ${joinedLength} must exceed the MongoDB limit`)
+
+    for (const topic of topics) {
+      await p1.instance.storeRetained({
+        cmd: 'publish',
+        topic,
+        payload: Buffer.from('test'),
+        qos: 0,
+        retain: true
+      })
+    }
+
+    const stream = p1.instance.createRetainedStreamCombi(topics)
+    const results = []
+    for await (const packet of stream) {
+      results.push(packet.topic)
+    }
+
+    t.assert.equal(results.length, 200, 'should retrieve all slash-heavy retained messages')
+    await cleanUpPersistence(t, p1)
+  })
+
+  test('retained messages batching: exact and wildcard patterns mixed', async (t) => {
+    t.plan(2)
+    await cleanDB()
+    const p1 = await setUpPersistence(t, '1', defaultDBopts)
+
+    const topics = [
+      'mixed/exact/one',
+      'mixed/exact/two',
+      'mixed/tree/branch/leaf',
+      'mixed/tree/branch/other',
+      'mixed/single/a/value',
+      'mixed/untouched/topic'
+    ]
+    for (const topic of topics) {
+      await p1.instance.storeRetained({
+        cmd: 'publish',
+        topic,
+        payload: Buffer.from('test'),
+        qos: 0,
+        retain: true
+      })
+    }
+
+    // 'mixed/tree/branch/leaf' is covered by both the exact filter and
+    // 'mixed/tree/#': the overlap must not yield it twice
+    const stream = p1.instance.createRetainedStreamCombi([
+      'mixed/exact/one',
+      'mixed/tree/#',
+      'mixed/tree/branch/leaf',
+      'mixed/single/+/value',
+      'mixed/exact/two'
+    ])
+    const results = []
+    for await (const packet of stream) {
+      results.push(packet.topic)
+    }
+
+    t.assert.deepStrictEqual(results.sort(), [
+      'mixed/exact/one',
+      'mixed/exact/two',
+      'mixed/single/a/value',
+      'mixed/tree/branch/leaf',
+      'mixed/tree/branch/other'
+    ], 'should retrieve exactly the matching topics')
+    t.assert.equal(new Set(results).size, results.length, 'should not yield duplicates')
+    await cleanUpPersistence(t, p1)
+  })
+
   test('prevent executing bulk when instance is destroyed', async (t) => {
     t.plan(1)
     await cleanDB()


### PR DESCRIPTION
## The bug

`createRetainedStreamCombi` joins subscription filters into one alternation regex. The batch budget added in #89 (`MAX_TOTAL_PATTERN_LENGTH`) counted **raw** filter lengths — but what MongoDB compiles is `RegExp.source`, where V8 escapes every `/` as `\/`. MQTT filters are slash-delimited, so a deep topic tree inflates ~10% on top of `escape-string-regexp`'s own expansions (`-` becomes `\x2d`, four bytes for one).

MongoDB's limit is 16384 bytes and the old budget left 1384 (9.2%) of headroom, so a slash-heavy topic tree still overshoots it. Captured from the mongod slow-query log on a production broker:

```
ns          mqttFreeboard.retained
branches    193 subscribe filters
raw bytes   14917   <- under the 15000 budget, so batching considered it safe
compiled    16484   <- what mongod actually parses
            -> Location51091 "pattern string is longer than the limit set by the application"

+1567 = 1341 slashes (+1 each) + 11 hyphens (+3) + 1 '$' (+1) + 192 separators
```

The throwing generator tears down the retained stream mid-iteration, so the subscribing client gets no retained messages for that batch or for any batch after it. It reproduces on every broker start for that deployment.

## The fix

- Budget against the compiled pattern (`new RegExp(branch).source.length`), never the raw filter length.
- Filters with no wildcard skip the regex entirely and go through `$in`.
- Wildcard filters become `^`-anchored literal prefixes.
- A single prefix too long to fit on its own is truncated instead of being passed through to fail (previously documented as "MongoDB will handle it or fail with a clear error"). The regex is only a pre-filter — `matcher.match` decides the real matches — so a shorter prefix stays correct, it just yields more candidates to discard.
- Deduplication now applies whenever more than one filter is produced. Previously it only ran inside the batching branch, so an exact filter overlapping a wildcard one could yield the same packet twice.

Both filter shapes also keep the `topic` index scan bounded, where the unanchored alternation had to walk the whole index. Measured on 500 retained topics, one match:

| filter | keysExamined | docsExamined |
| --- | --- | --- |
| `^`-anchored prefix | 2 | 1 |
| unanchored alternation (before) | 500 | 1 |
| `$in` exact | 4 | 2 |

## Tests

`retained messages batching: slash-heavy patterns stay under the MongoDB regex limit` fails on `master` with the exact production error and passes here. The fixture asserts its own regime — raw length within the old budget, compiled source over 16384 — so it cannot silently drift out of the case it is meant to cover.

A second test covers exact, `#` and `+` filters mixed in one call, and the no-duplicates guarantee.

68/68 pass, lint clean.
